### PR TITLE
Anti-aliased fonts for Linux

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,10 @@
  	:dev-dependencies [[lein-marginalia "0.6.0"]
  	                   ;[franks42/debug-repl "0.3.1-FS"]
                      [codox "0.5.0"]]
-  :jvm-opts ~(if (= (System/getProperty "os.name") "Mac OS X") ["-Xdock:name=Clj-NS-Browser"] [])
+  :jvm-opts ~(case (System/getProperty "os.name")
+               "Mac OS X" ["-Xdock:name=Clj-NS-Browser"]
+               "Linux" ["-Dawt.useSystemAAFontSettings=on"]
+               [])
   :java-source-paths ["src"]
   :java-source-path "src"
   :main clj-ns-browser.core)


### PR DESCRIPTION
I had to add this option in order to get anti-aliased fonts on my Linux system (Ubuntu 10.04). By default the fonts looked VERY bad. With this they look great. I don't know how other Linux systems look by default. 
